### PR TITLE
Server init

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"log"
 	"os"
 
@@ -9,10 +10,10 @@ import (
 )
 
 var (
-	wgAllocator      *allocator.IPAllocator
-	serverPrivateKey wgtypes.Key
-	serverPublicKey  wgtypes.Key
-	privateKeyFile   = "server_private.key"
+	wgAllocator        *allocator.IPAllocator
+	serverPrivateKey   wgtypes.Key
+	serverPublicKey    wgtypes.Key
+	privateKeyFile     = "server_private.key"
 	wasKeyGeneratedNow bool
 )
 
@@ -24,23 +25,29 @@ func init() {
 	}
 	log.Println("IPAllocator initialized successfully.")
 
-
-	serverPrivateKey, serverPublicKey, err = loadOrGenerateServerKeys()
+	serverPrivateKey, serverPublicKey, wasKeyGeneratedNow, err = loadOrGenerateServerKeys()
 	if err != nil {
 		log.Fatalf("Failed to initialize WireGuard server keys: %v", err)
 	}
 	log.Println("WireGuard server keys initialized.")
+
+	if wasKeyGeneratedNow {
+		log.Println("New WireGuard private key generated. Creating fresh server config")
+		writeInitialPeersFile(serverPrivateKey.String())
+	} else {
+		log.Println("Using existing WireGuard private key. Skipping config rewrite")
+	}
 }
 
 func GetAllocator() *allocator.IPAllocator {
 	return wgAllocator
 }
 
-func GetServerPublicKey() (string){
+func GetServerPublicKey() string {
 	return serverPublicKey.String()
 }
 
-func GetServerPrivateKey() (string) {
+func GetServerPrivateKey() string {
 	return serverPrivateKey.String()
 }
 
@@ -69,3 +76,17 @@ func loadOrGenerateServerKeys() (wgtypes.Key, wgtypes.Key, bool, error) {
 	return privKey, privKey.PublicKey(), true, nil
 }
 
+func writeInitialPeersFile(privateKey string) {
+	content := fmt.Sprintf(`[Interface]
+Address = 10.0.0.1/24
+PostUp = iptables -I FORWARD 1 -i wg0 -j ACCEPT; iptables -I FORWARD 1 -o wg0 -j ACCEPT; iptables -t nat -I POSTROUTING 1 -s 10.200.200.0/24 -o eth0 -j MASQUERADE
+PostDown = iptables -D FORWARD -i wg0 -j ACCEPT; iptables -D FORWARD -o wg0 -j ACCEPT; iptables -t nat -D POSTROUTING -s 10.200.200.0/24 -o eth0 -j MASQUERADE
+ListenPort = 51820
+PrivateKey = %s
+`, privateKey)
+
+	err := os.WriteFile("peers.conf", []byte(content), 0644)
+	if err != nil {
+		log.Fatalf("Failed to write peers.conf: %v", err)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,7 @@ var (
 	serverPrivateKey wgtypes.Key
 	serverPublicKey  wgtypes.Key
 	privateKeyFile   = "server_private.key"
+	wasKeyGeneratedNow bool
 )
 
 func init() {
@@ -43,28 +44,28 @@ func GetServerPrivateKey() (string) {
 	return serverPrivateKey.String()
 }
 
-func loadOrGenerateServerKeys() (wgtypes.Key, wgtypes.Key, error) {
+func loadOrGenerateServerKeys() (wgtypes.Key, wgtypes.Key, bool, error) {
 	// Try loading private key from file
 	if data, err := os.ReadFile(privateKeyFile); err == nil {
 		privKey, err := wgtypes.ParseKey(string(data))
 		if err != nil {
-			return wgtypes.Key{}, wgtypes.Key{}, err
+			return wgtypes.Key{}, wgtypes.Key{}, false, err
 		}
-		return privKey, privKey.PublicKey(), nil
+		return privKey, privKey.PublicKey(), false, nil
 	}
 
 	// Else generate a new one
 	privKey, err := wgtypes.GeneratePrivateKey()
 	if err != nil {
-		return wgtypes.Key{}, wgtypes.Key{}, err
+		return wgtypes.Key{}, wgtypes.Key{}, false, err
 	}
 
 	// Save private key to file
 	err = os.WriteFile(privateKeyFile, []byte(privKey.String()), 0600)
 	if err != nil {
-		return wgtypes.Key{}, wgtypes.Key{}, err
+		return wgtypes.Key{}, wgtypes.Key{}, false, err
 	}
 
-	return privKey, privKey.PublicKey(), nil
+	return privKey, privKey.PublicKey(), true, nil
 }
 

--- a/server-template.conf
+++ b/server-template.conf
@@ -1,0 +1,6 @@
+[Interface]
+Address = 10.0.0.1/24
+PostUp =   iptables -I FORWARD 1 -i wg0 -j ACCEPT; iptables -I FORWARD 1 -o wg0 -j ACCEPT; iptables -t nat -I POSTROUTING 1 -s 10.200.200.0/24 -o eth0 -j MASQUERADE
+PostDown = iptables -D FORWARD -i wg0 -j ACCEPT;   iptables -D FORWARD -o wg0 -j ACCEPT; iptables -t nat -D POSTROUTING -s 10.200.200.0/24 -o eth0 -j MASQUERADE
+ListenPort = 51820
+PrivateKey = %s


### PR DESCRIPTION
now, during first run, the private key will be created alongside with the wireguard template containing [Interface] data for the wireguard server. 